### PR TITLE
Quickfix for redirecting to riotchat

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,10 @@ const routes = [
   { path: '/whitepaper/en-US', redirect: '/whitepaper' },
   { path: '/validator', redirect: '/validators' },
   { path: '/blog/:entry', redirect: '/blog' },
+  { path: '/riot',
+    beforeEnter: () => {
+      location.assign('https://riot.im/app/#/room/#cosmos:matrix.org')
+  }},
 
   // wildcards
   { path: '/404', component: r('404') },


### PR DESCRIPTION
This does not leverage the dynamic link from aib-data.