### PR TITLE
update primary action to dev chat, fix links

### DIFF
--- a/src/components/common/AppFooter.vue
+++ b/src/components/common/AppFooter.vue
@@ -7,22 +7,22 @@
     .footbot-menu
       .footbot-menu__title Cosmos
       .footbot-menu__items
-        router-link(to="/about").footbot-menu__item About
+        router-link(to="/about").footbot-menu__item Introduction
+        router-link(to="/about/faq").footbot-menu__item FAQ
         router-link(to="/about/team").footbot-menu__item Team
         a(href="https://tendermint.com/careers" target="_blank").footbot-menu__item Careers
-        router-link(to="/about/faq").footbot-menu__item FAQ
         a(href="https://fundraiser.cosmos.network" target="_blank").footbot-menu__item Fundraiser
     .footbot-menu
       .footbot-menu__title Downloads
       .footbot-menu__items
-        router-link(to="/developers/whitepaper").footbot-menu__item Whitepaper
-        router-link(to="/about/assets").footbot-menu__item Visual Assets
+        router-link(to="/about/whitepaper").footbot-menu__item Whitepaper
+        a(href="https://github.com/cosmos/cosmos-ui" target="_blank").footbot-menu__item Cosmos UI
+        router-link(to="/assets").footbot-menu__item Visual Assets
     .footbot-menu
       .footbot-menu__title Developers
       .footbot-menu__items
         a(href="https://github.com/cosmos" target="_blank").footbot-menu__item Cosmos GitHub
         a(href="https://github.com/cosmos/cosmos-sdk" target="_blank").footbot-menu__item Cosmos SDK
-        a(href="https://github.com/cosmos/cosmos-ui" target="_blank").footbot-menu__item Cosmos UI
         a(href="https://tendermint.com" target="_blank").footbot-menu__item Tendermint
         router-link(to="/validators").footbot-menu__item Validators
 </template>

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -16,7 +16,7 @@ header.app-header
         a(:href='links.cosmos.blog' @click.native='close' target='_blank')
           span.label Blog
           i.fa.fa-medium
-        a(:href='links.cosmos.github' @click.native='close' target='_blank')
+        a(:href='links.cosmos.github.organization' @click.native='close' target='_blank')
           span.label Github
           i.fa.fa-github
 </template>

--- a/src/components/pages/PageDevIndex.vue
+++ b/src/components/pages/PageDevIndex.vue
@@ -8,7 +8,7 @@ page(title="Developers" subtitle="Learn how to bootstrap your blockchain with Co
   p Gaia is a testnet designed to get validators acquainted with staking concepts and procedures. For testing purposes, the Gaia validator set is determined as validators with the top 100 bonded atoms. The validator set is undated every block. All bonding and unbonding is instantaneous (no queue). Absent features: delegation, validator rewards, and the unbonding wait period.
 
   ul
-    li: a(href="https://github.com/cosmos/gaia") Gaia on GitHub
+    li: a(href="https://github.com/cosmos/gaia" target="_blank") Gaia on GitHub
     li: router-link(to="/validators") Learn about Cosmos Validators
 
   h2 Blockchain Frameworks
@@ -16,38 +16,38 @@ page(title="Developers" subtitle="Learn how to bootstrap your blockchain with Co
   h3 Cosmos SDK
   p The Cosmos SDK is an ABCI framework written in Golang that affords you all the tools you need to rapidly develop robust blockchains and blockchain applications which are interoperable with the Cosmos Hub. It is a blockchain development 'starter-pack' of common blockchain modules while not enforcing their use thus giving maximum flexibility for application customization. It is perfect to build highly-customizable public proof-of-stake blockchains.
 
-  p NOTE: The Cosmos SDK is under heavy development and it's not yet ready for release. Keep up to date with Cosmos SDK news #[a(href="https://blog.cosmos.network") on our blog].
+  p NOTE: The Cosmos SDK is under heavy development and it's not yet ready for release. Keep up to date with Cosmos SDK news #[a(href="https://blog.cosmos.network" target="_blank") on our blog].
 
   //- ul
-    li: a(href="https://github.com/cosmos/cosmos-sdk") Cosmos SDK on GitHub
-    li: a(href="http://cosmos-sdk.readthedocs.io/en/latest/") Cosmos SDK Documentation
+    li: a(href="https://github.com/cosmos/cosmos-sdk" target="_blank") Cosmos SDK on GitHub
+    li: a(href="http://cosmos-sdk.readthedocs.io/en/latest/" target="_blank") Cosmos SDK Documentation
 
   h3 Application-Blockchain Interface (ABCI)
   p The Application-Blockchain Interface (ABCI) allows you to deploy the business logic of your blockchain application in any language. It handles the connection with the underlying Tendermint engine, which is responsible for the networking and consensus parts of the software. With the ABCI, you can deploy any type of blockchain application - public or private - in no time.
   ul
-    li: a(href="http://tendermint.readthedocs.io/projects/tools/en/master/introduction.html#abci-overview") ABCI in Docs
-    li: a(href="https://github.com/tendermint/abci") ABCI on Github
+    li: a(href="http://tendermint.readthedocs.io/projects/tools/en/master/introduction.html#abci-overview" target="_blank") ABCI in Docs
+    li: a(href="https://github.com/tendermint/abci" target="_blank") ABCI on Github
 
 
   h3 Ethermint
   p Ethermint is a blazing fast Proof-of-Stake implementation of Ethereum that is built on top of Tendermint using the ABCI protocol. Ethermint lets you use the full power of the Ethereum Virtual Machine in connection to other blockchains (with IBC) on the Cosmos Network.
   ul
-    li: a(href="https://ethermint.zone") Ethermint Website
-    li: a(href="https://github.com/tendermint/ethermint") Ethermint on GitHub
+    li: a(href="https://ethermint.zone" target="_blank") Ethermint Website
+    li: a(href="https://github.com/tendermint/ethermint" target="_blank") Ethermint on GitHub
 
   h3 Lotion
   p Lotion is a new way to create blockchain apps in JavaScript, which aims to make writing new blockchains fast and fun. It builds on top of Tendermint using the ABCI protocol. Lotion lets you write secure, scalable applications that can easily interoperate with other blockchains on the Cosmos Network using IBC.
   ul
-    li: a(href="https://lotionjs.com") Lotion Website
-    li: a(href="https://github.com/keppel/lotion") Lotion on GitHub
+    li: a(href="https://lotionjs.com" target="_blank") Lotion Website
+    li: a(href="https://github.com/keppel/lotion" target="_blank") Lotion on GitHub
 
   h2 Blockchain Consensus
 
   h3 Tendermint
   p Tendermint is the byzantine-fault tolerant consensus engine behind Cosmos SDK, Ethermint, and Lotion. Tendermint applications can be written in any programming language.
   ul
-    li: a(href="https://tendermint.com") Tendermint Website
-    li: a(href="https://github.com/tendermint/tendermint") Tendermint on GitHub
+    li: a(href="https://tendermint.com" target="_blank") Tendermint Website
+    li: a(href="https://github.com/tendermint/tendermint" target="_blank") Tendermint on GitHub
 </template>
 
 <script>

--- a/src/components/sections/SectionCover.vue
+++ b/src/components/sections/SectionCover.vue
@@ -7,11 +7,11 @@
     .section-cover__action
       btn(
         type="anchor"
-        href="https://github.com/cosmos/cosmos-ui/releases/latest"
+        href="https://riot.im/app/#/room/#cosmos:matrix.org"
         size="lg"
-        icon="file_download"
+        icon="chat"
         target="_blank"
-        value="Download Wallet")
+        value="Join Developer Chat")
     .section-cover__scroll
       btn(icon="arrow_downward" v-scroll-to="'#section-what'")
 </template>


### PR DESCRIPTION
Since the UI is not in a secure state yet, it shouldn't be our primary action. Let's send them to chat instead, and let's use dev chat because Riot/Matrix is instantly accessible while Telegram requires an app.

Also updates most of the links on the Developers page to use `target="_blank"

Also fixes two links in the footer