### PR TITLE
homepage font tweak

### DIFF
--- a/src/components/pages/PageSecurity.vue
+++ b/src/components/pages/PageSecurity.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .page
   page-menu
-  page(title="Security" subtitle="Security is a core value at Cosmos & Tendermint. Learn how earn bounties by reporting vulnerabilities.")
+  page(title="Security" subtitle="Security is a core value at Cosmos & Tendermint. Learn how to earn bounties by reporting vulnerabilities.")
     text-container: text-content
 </template>
 

--- a/src/components/sections/SectionCover.vue
+++ b/src/components/sections/SectionCover.vue
@@ -61,7 +61,7 @@ export default {
   shadow()
 
 .section-cover__wordmark
-  padding-top 17.5vh
+  padding-top 20vh
   display flex
   align-items center
 
@@ -70,15 +70,14 @@ export default {
 
 .section-cover__tagline
   text-align center
-  font-weight 400
-  letter-spacing 0.025em
+  letter-spacing 0.0375em
   text-shadow hsla(0,0,0,1) 0 0 0.5em
 
-  padding-top 5vh
+  padding-top 7.5vh
   max-width 20em
 
 .section-cover__action
-  padding-top 15vh
+  padding-top 22.5vh
 
 .section-cover__action .ni-btn
   shadow()
@@ -124,55 +123,26 @@ export default {
 /* END queries for bg image */
 
 @media screen and (min-width: 768px) and (orientation: portrait)
+  .section-cover__tagline
+    font-size xl
   .section-cover__img
-    width 36vw
+    width 45vw
 
-@media screen and (orientation: landscape)
-  .section-cover__img
-    width 18vw
-
-@media screen and (min-width: 375px) and (min-height: 812px) and (orientation: portrait)
-  .section-cover__action
-    padding-top 20vh
-
-@media screen and (min-width: 414px)
+@media screen and (min-width: 1024px) and (orientation: landscape)
   .section-cover__tagline
     font-size lg
 
-@media screen and (min-width: 768px)
-  .section-cover__wordmark
-    padding-top 12.5vh
+  .section-cover__img
+    width 25vw
 
-  .section-cover__container
-    padding 0 3rem
-
-@media screen and (min-width: 1024px)
+@media screen and (min-width: 1024px) and (orientation: portrait)
   .section-cover__tagline
-    padding-top 6.25vh
+    font-size 3.25vw
 
-@media screen and (min-height: 1024px)
+@media screen and (min-width: 1280px) and (orientation: landscape)
   .section-cover__tagline
-    font-size xl
-
-@media screen and (min-width: 1280px)
-  .section-cover__wordmark
-    padding-top 12vh
-
-  .section-cover__action
-    padding-top 20vh
-
-@media screen and (min-width: 1440px)
-  .section-cover__wordmark
-    padding-top 10vh
-
-@media screen and (min-width: 1680px)
-  .section-cover__wordmark
-    padding-top 8vh
-
-@media screen and (min-width: 1920px)
-  .section-cover__wordmark
-    padding-top 6vh
+    font-size 1.375vw + 0.25vh
 
   .section-cover__img
-    width 24rem
+    width 20vw
 </style>


### PR DESCRIPTION
Removes a lot of the resolution dependent font and logo sizing for something simpler and better looking. Also drastically improves the spacing for the main action!

# old @ 1024px wide

<img width="780" alt="screen shot 2017-12-20 at 1 36 56 pm" src="https://user-images.githubusercontent.com/172531/34191509-eb78d4f4-e58a-11e7-8b84-8cba12f041da.png">

# new @ 1024px wide

<img width="780" alt="screen shot 2017-12-20 at 1 37 05 pm" src="https://user-images.githubusercontent.com/172531/34191511-edb15214-e58a-11e7-8832-fd9bc2cb8def.png">

