### PR TITLE
peng/fix-roadmap-dependency-arrows

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,7 +61,6 @@ export default {
   },
   mounted () {
     this.$store.commit('initializeLinks')
-    this.$store.commit('initializeRoadmap')
     this.$store.commit('initializePeople')
   },
   store

--- a/src/components/pages/PageRoadmap.vue
+++ b/src/components/pages/PageRoadmap.vue
@@ -174,6 +174,9 @@ export default {
       nodes.gui.map(n => n.children.map(to => connect($(n.id), $(to))))
     }
   },
+  mounted () {
+    this.$store.commit('initializeRoadmap')
+  },
   watch: {
     nodes: function (newNodes, oldNodes) {
       this.setDependencies()

--- a/src/components/pages/PageRoadmap.vue
+++ b/src/components/pages/PageRoadmap.vue
@@ -161,18 +161,17 @@ export default {
       }
       this.arrows.push(arrow)
     },
-    setDependencies () {
+    async setDependencies () {
       let $ = (el) => this.$el.querySelector('#' + el)
       let connect = this.connect
       let nodes = this.nodes
 
-      // todo: fix this hack for nodes to load before drawing dependencies
-      setTimeout(function () {
-        nodes.hub.map(n => n.children.map(to => connect($(n.id), $(to))))
-        nodes.sdk.map(n => n.children.map(to => connect($(n.id), $(to))))
-        nodes.tmc.map(n => n.children.map(to => connect($(n.id), $(to))))
-        nodes.gui.map(n => n.children.map(to => connect($(n.id), $(to))))
-      }, 1000)
+      await this.$nextTick()
+
+      nodes.hub.map(n => n.children.map(to => connect($(n.id), $(to))))
+      nodes.sdk.map(n => n.children.map(to => connect($(n.id), $(to))))
+      nodes.tmc.map(n => n.children.map(to => connect($(n.id), $(to))))
+      nodes.gui.map(n => n.children.map(to => connect($(n.id), $(to))))
     }
   },
   watch: {

--- a/src/store/json/roadmapNodes.json
+++ b/src/store/json/roadmapNodes.json
@@ -191,7 +191,7 @@
       "span": 1,
       "date": "",
       "notes": "Cosmos-SDK 0.9.0, or the 'New SDK', initializes genesis state and marks a significant milestone, in that everything (Gaia-3, Cosmos-UI 0.5.0, and partner projects) gets unblocked.",
-      "url": ""
+      "url": "https://github.com/cosmos/cosmos-sdk/projects/2"
     },
     {
       "id": "sdk-0-10",
@@ -202,7 +202,7 @@
       "span": 1,
       "date": "",
       "notes": "Cosmos SDK 0.10.0 includes the light client daemon (LCD) feature.",
-      "url": ""
+      "url": "https://github.com/cosmos/cosmos-sdk/projects/4"
     },
     {
       "id": "sdk-0-11",


### PR DESCRIPTION
Sometimes the node dependency arrows didn't load until you hard refreshed the /roadmap page. This PR should fix that issue.


### Before

![018 - roadmap - cosmos network - https___cosmos network_roadmap](https://user-images.githubusercontent.com/172531/36086894-f027498c-1009-11e8-96cf-9507e7d27797.png)
